### PR TITLE
Fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ __San Francisco Pro__ for iOS, macOS, and tvOS
 
 __San Francisco Compact__ for watchOS 
 
-__San Francisco Compact__ for Terminal and Code Editor 
+__San Francisco Mono__ for Terminal and Code Editor 
 
 --
 


### PR DESCRIPTION
Changed wrong "San Francisco Compact" to "San Francisco Mono".